### PR TITLE
fix(release): prevent double-bump and revert v2.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "commit-wizard-cli"
-version = "2.5.0"
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "commit-wizard-core"
-version = "2.5.0"
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "commit-wizard-napi"
-version = "2.5.0"
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "commit-wizard-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "commit-wizard-cli"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "commit-wizard-core"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "commit-wizard-napi"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "commit-wizard-core",


### PR DESCRIPTION
- revert accidental v2.6.0 commit and delete tag
- fix release-tool tag ancestry detection to stop double-bumps
- this stabilises prepare-release on main.